### PR TITLE
Replaces 0 value output with nulldata output (op_return)

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ var breakTheJpegs = async () => {
 	  }],
 	  vout : [{
 	    value: 0,
-	    scriptPubKey: Address.toScriptPubKey('bcrt1q6zpf4gefu4ckuud3pjch563nm7x27u4ruahz3y')
+	    scriptPubKey: ['OP_RETURN', '']
 	  }]
 	})
 


### PR DESCRIPTION
Hey, this replaces the valid, spendable 0 value final output with an unspendable nulldata output.
Won't bloat the UTXO set and the transaction will also be smaller.